### PR TITLE
Update parkSlope.js

### DIFF
--- a/prod/models/parkSlope.js
+++ b/prod/models/parkSlope.js
@@ -46,8 +46,7 @@ let models = [{
   buffer: false
 }, {
   id_sub: 8,
-  // napkins
-  name: 'banana',
+  name: 'napkins',
   startTime: 235,
   endTime: 241,
   buffer: false


### PR DESCRIPTION
fixed ID 8, 'napkins' are now live.